### PR TITLE
Fix route planner geocoding reuse

### DIFF
--- a/intelligent-route-planner.js
+++ b/intelligent-route-planner.js
@@ -122,9 +122,19 @@ class IntelligentRoutePlanner {
     // ======================================================================
     async geocodeAppointments(appointments) {
         console.log('🗺️ Geocoding von Adressen mit Google Maps API...');
-        
+
         const geocoded = [];
         for (const apt of appointments) {
+            // Bereits vorhandene Koordinaten nutzen
+            if (apt.lat && apt.lng) {
+                geocoded.push({
+                    ...apt,
+                    geocoded: true,
+                    geocoding_method: 'database'
+                });
+                continue;
+            }
+
             try {
                 const coords = await this.geocodingService.geocodeAddress(apt.address);
                 geocoded.push({
@@ -153,7 +163,7 @@ class IntelligentRoutePlanner {
                 }
             }
         }
-        
+
         return geocoded.filter(apt => apt.geocoded); // Nur geocodierte Termine
     }
 

--- a/server.js
+++ b/server.js
@@ -605,7 +605,10 @@ async function performMaxEfficiencyOptimization(appointments, weekStart, driverI
                 is_fixed: apt.is_fixed,
                 fixed_date: apt.fixed_date,
                 fixed_time: apt.fixed_time,
-                notes: apt.notes
+                notes: apt.notes,
+                lat: apt.lat,
+                lng: apt.lng,
+                geocoded: apt.geocoded
             };
         });
 


### PR DESCRIPTION
## Summary
- re-use stored geocoding data when optimizing routes
- provide latitude/longitude fields to the route planner

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849586d8a34832899d4c0545808c37e