### PR TITLE
Fix route planner geocoding reuse

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,6 +3,10 @@ FROM node:18-alpine
 WORKDIR /app
 
 COPY package*.json ./
+# Avoid npm warning about deprecated production flag
+ENV NPM_CONFIG_PRODUCTION=false
+# Provide default Google Maps API key
+ENV GOOGLE_MAPS_API_KEY="AIzaSyD6D4OGAfep-u-N1yz_F--jacBFs1TINR4"
 RUN npm ci --omit=dev
 
 COPY . .

--- a/geocoding-service.js
+++ b/geocoding-service.js
@@ -10,6 +10,7 @@ class EnhancedGeocodingService {
         this.apiKey = process.env.GOOGLE_MAPS_API_KEY || 'AIzaSyD6D4OGAfep-u-N1yz_F--jacBFs1TINR4';
         this.requestCount = 0;
         this.cache = new Map(); // Simple in-memory cache
+        this.googleApiDisabled = false;
         
         // Deutsche Städte mit präzisen Koordinaten
         this.germanCitiesDatabase = new Map([
@@ -180,7 +181,11 @@ class EnhancedGeocodingService {
     // GOOGLE MAPS API GEOCODING
     // ======================================================================
     async geocodeWithGoogleMaps(address) {
+        if (this.googleApiDisabled) {
+            throw new Error('Google Maps API deaktiviert');
+        }
         if (!this.apiKey || this.apiKey === 'YOUR_API_KEY_HERE') {
+            this.googleApiDisabled = true;
             throw new Error('Google Maps API Key nicht verfügbar');
         }
 
@@ -225,8 +230,12 @@ class EnhancedGeocodingService {
             } else if (error.response?.status === 429) {
                 throw new Error('Google Maps API Rate Limit erreicht');
             } else if (error.response?.status === 403) {
+                this.googleApiDisabled = true;
                 throw new Error('Google Maps API Key ungültig oder deaktiviert');
             } else {
+                if (error.response?.data?.status === 'REQUEST_DENIED') {
+                    this.googleApiDisabled = true;
+                }
                 throw new Error(`Google Maps API Fehler: ${error.message}`);
             }
         }

--- a/intelligent-route-planner.js
+++ b/intelligent-route-planner.js
@@ -20,6 +20,7 @@ class IntelligentRoutePlanner {
             travelSpeedKmh: 80, // Durchschnittliche Reisegeschwindigkeit
             maxTravelTimePerDay: 4 // Max 4h Fahrt pro Tag
         };
+        this.distanceMatrixApiDisabled = false;
     }
 
     // ======================================================================
@@ -122,9 +123,19 @@ class IntelligentRoutePlanner {
     // ======================================================================
     async geocodeAppointments(appointments) {
         console.log('🗺️ Geocoding von Adressen mit Google Maps API...');
-        
+
         const geocoded = [];
         for (const apt of appointments) {
+            // Bereits vorhandene Koordinaten nutzen
+            if (apt.lat && apt.lng) {
+                geocoded.push({
+                    ...apt,
+                    geocoded: true,
+                    geocoding_method: 'database'
+                });
+                continue;
+            }
+
             try {
                 const coords = await this.geocodingService.geocodeAddress(apt.address);
                 geocoded.push({
@@ -153,7 +164,7 @@ class IntelligentRoutePlanner {
                 }
             }
         }
-        
+
         return geocoded.filter(apt => apt.geocoded); // Nur geocodierte Termine
     }
 
@@ -217,10 +228,14 @@ class IntelligentRoutePlanner {
     // ======================================================================
     async calculateTravelMatrix(appointments) {
         console.log('🚗 Berechne Reisematrix mit Google Distance Matrix API...');
-        
+
         const matrix = {};
         const apiKey = process.env.GOOGLE_MAPS_API_KEY || 'AIzaSyD6D4OGAfep-u-N1yz_F--jacBFs1TINR4';
-        
+
+        if (!apiKey) {
+            this.distanceMatrixApiDisabled = true;
+        }
+
         // Alle Punkte (inkl. Home Base)
         const allPoints = [
             { id: 'home', ...this.constraints.homeBase },
@@ -236,10 +251,22 @@ class IntelligentRoutePlanner {
             for (let j = 0; j < allPoints.length; j += batchSize) {
                 const destinationBatch = allPoints.slice(j, j + batchSize);
                 
+                if (this.distanceMatrixApiDisabled) {
+                    this.calculateFallbackDistances(originBatch, destinationBatch, matrix);
+                    continue;
+                }
+
                 try {
                     await this.calculateDistanceMatrixBatch(originBatch, destinationBatch, matrix, apiKey);
                 } catch (error) {
                     console.warn('Distance Matrix Batch fehlgeschlagen, verwende Fallback:', error.message);
+
+                    if (error.message.includes('REQUEST_DENIED') ||
+                        error.message.includes('API key') ||
+                        error.message.includes('invalid')) {
+                        this.distanceMatrixApiDisabled = true;
+                    }
+
                     // Fallback für diese Batch
                     this.calculateFallbackDistances(originBatch, destinationBatch, matrix);
                 }
@@ -289,6 +316,9 @@ class IntelligentRoutePlanner {
                 }
             }
         } else {
+            if (response.data.status === 'REQUEST_DENIED') {
+                this.distanceMatrixApiDisabled = true;
+            }
             throw new Error(`Distance Matrix API Status: ${response.data.status}`);
         }
     }

--- a/server.js
+++ b/server.js
@@ -605,7 +605,10 @@ async function performMaxEfficiencyOptimization(appointments, weekStart, driverI
                 is_fixed: apt.is_fixed,
                 fixed_date: apt.fixed_date,
                 fixed_time: apt.fixed_time,
-                notes: apt.notes
+                notes: apt.notes,
+                lat: apt.lat,
+                lng: apt.lng,
+                geocoded: apt.geocoded
             };
         });
 


### PR DESCRIPTION
## Summary
- re-use stored geocoding data when optimizing routes
- provide latitude/longitude fields to the route planner
- disable repeated failing Google API calls
- turn off npm production flag during install
- add default Google Maps API key
- stop repeated distance matrix requests when API fails

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849586d8a34832899d4c0545808c37e