### PR TITLE
Fix conflict markers in intelligent-route-planner.js

### DIFF
--- a/intelligent-route-planner.js
+++ b/intelligent-route-planner.js
@@ -281,10 +281,7 @@ class IntelligentRoutePlanner {
                     const distance = entry.distance || 0;
                     matrix[from][to].duration = distance / this.constraints.travelSpeedKmh;
                 }
-<<<<<<< yywhvx-codex/optimierung-der-routenplanung-im-backend
                 matrix[from][to].duration += this.constraints.travelTimePadding;
-=======
->>>>>>> main
             });
         });
         return matrix;


### PR DESCRIPTION
## Summary
- clean up leftover merge conflict markers in `intelligent-route-planner.js`

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684ec2ccb7188328a3842c705b824aa3