### PR TITLE
Implement 42.5h limit and 30‑minute scheduling

### DIFF
--- a/intelligent-route-planner.js
+++ b/intelligent-route-planner.js
@@ -5,7 +5,7 @@ class IntelligentRoutePlanner {
     constructor() {
         this.geocodingService = new EnhancedGeocodingService();
         this.constraints = {
-            maxWorkHoursPerWeek: 50,        // Realistische 50h für Testimonials
+            maxWorkHoursPerWeek: 42.5,      // Max 40h Arbeit + 2.5h Pausen
             maxWorkHoursPerDay: 12,         // Arbeit + Fahrtzeit (Ende 18:00)
             flexWorkHoursPerDay: 14,        // Absolute Obergrenze mit Überstunden
             workStartTime: 6,               // Früh starten für lange Fahrten
@@ -505,12 +505,13 @@ class IntelligentRoutePlanner {
             }
             
             let startTime = day.lastAppointmentEnd + travelFromCurrent.duration;
-            
+
             if (travelFromCurrent.duration > 2) {
                 startTime += 0.5;
             }
-            
+
             startTime = Math.max(startTime, this.constraints.workStartTime);
+            startTime = Math.round(startTime * 2) / 2; // nur 30‑Minuten‑Schritte
             
             const appointmentEnd = startTime + this.constraints.appointmentDuration;
             
@@ -614,6 +615,7 @@ class IntelligentRoutePlanner {
         
         let startTime = day.lastAppointmentEnd + travelFromCurrent.duration + 0.5;
         startTime = Math.max(startTime, this.constraints.workStartTime);
+        startTime = Math.round(startTime * 2) / 2; // nur 30‑Minuten‑Schritte
         
         return {
             dayIndex: bestDay,
@@ -872,14 +874,15 @@ class IntelligentRoutePlanner {
     // HILFSFUNKTIONEN
     // ======================================================================
     formatTime(hours) {
-        const h = Math.floor(hours);
-        const m = Math.round((hours - h) * 60);
-        
+        const rounded = Math.round(hours * 2) / 2; // nur 30‑Minuten‑Schritte
+        const h = Math.floor(rounded);
+        const m = Math.round((rounded - h) * 60);
+
         // FIX: 60 Minuten korrekt behandeln
         if (m >= 60) {
             return `${(h + 1).toString().padStart(2, '0')}:00`;
         }
-        
+
         return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
     }
 

--- a/server.js
+++ b/server.js
@@ -917,6 +917,7 @@ async function planWeekWithClusters(clusters, allAppointments, weekStart) {
                             timeToHours(slot.startTime),
                             prevApt ? timeToHours(prevApt.endTime) + travelFromPrev : (dayIndex === 0 ? 9 + travelFromPrev : timeToHours(slot.startTime))
                         );
+                        startTimeHours = Math.round(startTimeHours * 2) / 2; // nur 30‑Minuten‑Schritte
 
                         let endTimeHours = startTimeHours + 3;
 
@@ -1146,8 +1147,9 @@ function timeToHours(timeStr) {
 
 function hoursToTime(hours) {
     hours = ((hours % 24) + 24) % 24; // Wrap around 24h and avoid negatives
-    const h = Math.floor(hours);
-    const m = Math.round((hours - h) * 60);
+    const rounded = Math.round(hours * 2) / 2; // nur 30‑Minuten‑Schritte
+    const h = Math.floor(rounded);
+    const m = Math.round((rounded - h) * 60);
     return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
 }
 
@@ -1281,7 +1283,7 @@ function formatOptimizedWeek(week, weekStart) {
             efficiency: {
                 travelEfficiency: totalWorkHours > 0 ? 
                     Math.round((1 - totalTravelHours / (totalWorkHours + totalTravelHours)) * 100) / 100 : 0,
-                weekUtilization: Math.round((totalWorkHours / 50) * 100) / 100
+                weekUtilization: Math.round((totalWorkHours / 42.5) * 100) / 100
             }
         },
         generatedAt: new Date().toISOString()


### PR DESCRIPTION
## Summary
- enforce 40h workweek (42.5h inkl. Pausen) in route planner
- round all appointment and travel times to 30‑minute increments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ec6feff288328a42516f680d5fa11