### PR TITLE
Fix appointment filtering

### DIFF
--- a/server.js
+++ b/server.js
@@ -387,7 +387,7 @@ app.get('/api/appointments', async (req, res) => {
     try {
         const rows = await new Promise((resolve, reject) => {
             db.all(
-                "SELECT * FROM appointments WHERE (on_hold IS NULL OR on_hold = '' OR TRIM(on_hold) = '') ORDER BY created_at DESC",
+                "SELECT * FROM appointments WHERE (on_hold IS NULL OR on_hold = '' OR TRIM(on_hold) = '') AND (is_fixed IS NULL OR is_fixed = 0) ORDER BY created_at DESC",
                 (err, result) => (err ? reject(err) : resolve(result))
             );
         });


### PR DESCRIPTION
## Summary
- ensure `/api/appointments` no longer returns already fixed appointments

## Testing
- `node -e "require('./server');"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684ecd5fcdb08328a5f98379a98d2cf1