### PR TITLE
Fix duplicate const declarations

### DIFF
--- a/intelligent-route-planner.js
+++ b/intelligent-route-planner.js
@@ -80,7 +80,6 @@ class IntelligentRoutePlanner {
                 isProposal: apt.status === 'vorschlag',
                 // Einige Datenbanken liefern Zahlen als Strings -> Boolean cast
                 isFixed: Boolean(apt.is_fixed),
-                isFixed: apt.is_fixed === 1,
                 fixedDate: apt.fixed_date,
                 fixedTime: apt.fixed_time,
                 duration: apt.duration || 3,
@@ -396,7 +395,6 @@ class IntelligentRoutePlanner {
        
         // Auch Termine ohne feste Uhrzeit berücksichtigen (Standard 10:00)
         const fixedAppointments = appointments.filter(a => a.isFixed && a.fixedDate);
-        const fixedAppointments = appointments.filter(a => a.isFixed && a.fixedDate && a.fixedTime);
         const confirmedAppointments = appointments.filter(apt => apt.isConfirmed && !apt.isFixed);
         const proposalAppointments = appointments.filter(apt => apt.isProposal && !apt.isFixed);
 
@@ -452,7 +450,6 @@ class IntelligentRoutePlanner {
             const day = week[dayIndex];
             const startTimeStr = apt.fixedTime || '10:00';
             const startHours = this.timeToHours(startTimeStr);
-            const startHours = this.timeToHours(apt.fixedTime || '10:00');
             const endHours = startHours + (apt.duration || this.constraints.appointmentDuration);
 
             const conflict = day.appointments.some(a =>
@@ -466,7 +463,6 @@ class IntelligentRoutePlanner {
             day.appointments.push({
                 ...apt,
                 startTime: startTimeStr,
-                startTime: apt.fixedTime,
                 endTime: this.formatTime(endHours),
                 travelTimeThere: 0,
                 isFixed: true,


### PR DESCRIPTION
## Summary
- remove duplicate `isFixed` field
- drop repeated `fixedAppointments` and start time variables in scheduling

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684ed0fefdd08328a22c5d919a8c6743