### PR TITLE
Fix route planner scheduling

### DIFF
--- a/server.js
+++ b/server.js
@@ -474,8 +474,13 @@ app.post('/api/routes/optimize', validateSession, async (req, res) => {
             const planner = new IntelligentRoutePlanner();
             optimizedRoute = await planner.optimizeWeek(selectedAppointments, weekStart, driverId);
         } catch (plannerError) {
-            console.warn('⚠️ Intelligente Planung fehlgeschlagen, nutze Fallback:', plannerError.message);
-            optimizedRoute = await performMaxEfficiencyOptimization(selectedAppointments, weekStart, driverId);
+            console.error('❌ Intelligente Planung fehlgeschlagen:', plannerError.message);
+            return res.status(500).json({
+                success: false,
+                error: 'Routenoptimierung fehlgeschlagen',
+                details: plannerError.message,
+                route: createEmptyWeekStructure(weekStart)
+            });
         }
 
         // 5. Route speichern


### PR DESCRIPTION
## Summary
- relax daily workload check to include travel time
- search day for available time slots when planning
- allow overnights based on distance threshold
- add helper to calculate available slots
- improve stats check and disable cluster fallback

## Testing
- `node -c intelligent-route-planner.js`
- `node -c server.js`


------
https://chatgpt.com/codex/tasks/task_e_6852aa6fd26c8328b426cedc807fede3