### PR TITLE
Improve API key handling and add distance cache

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 COPY package*.json ./
 # Avoid npm warning about deprecated production flag
 ENV NPM_CONFIG_PRODUCTION=false
-# Provide default Google Maps API key
-ENV GOOGLE_MAPS_API_KEY="AIzaSyD6D4OGAfep-u-N1yz_F--jacBFs1TINR4"
+# Google Maps API key must be provided at runtime
+ENV GOOGLE_MAPS_API_KEY=""
 RUN npm ci --omit=dev
 
 COPY . .

--- a/geocoding-service.js
+++ b/geocoding-service.js
@@ -7,7 +7,10 @@ const axios = require('axios');
 
 class EnhancedGeocodingService {
     constructor() {
-        this.apiKey = process.env.GOOGLE_MAPS_API_KEY || 'AIzaSyD6D4OGAfep-u-N1yz_F--jacBFs1TINR4';
+        this.apiKey = process.env.GOOGLE_MAPS_API_KEY;
+        if (!this.apiKey) {
+            throw new Error('Google Maps API Key nicht konfiguriert');
+        }
         this.requestCount = 0;
         this.cache = new Map(); // Simple in-memory cache
         this.googleApiDisabled = false;

--- a/intelligent-route-planner.js
+++ b/intelligent-route-planner.js
@@ -156,7 +156,7 @@ class IntelligentRoutePlanner {
         console.log('💰 KOSTEN-SPAR-MODUS AKTIV');
 
         const matrix = {};
-        const apiKey = process.env.GOOGLE_MAPS_API_KEY || 'AIzaSyD6D4OGAfep-u-N1yz_F--jacBFs1TINR4';
+        const apiKey = process.env.GOOGLE_MAPS_API_KEY;
 
         if (!apiKey) {
             throw new Error('Google Maps API Key nicht konfiguriert!');

--- a/server.js
+++ b/server.js
@@ -18,12 +18,6 @@ console.log('🔍 Environment Variables Debug:');
 console.log('NODE_ENV:', process.env.NODE_ENV);
 console.log('GOOGLE_MAPS_API_KEY exists:', !!process.env.GOOGLE_MAPS_API_KEY);
 
-// Fallback API Key
-if (!process.env.GOOGLE_MAPS_API_KEY) {
-    console.log('⚠️ Setting fallback API key');
-    process.env.GOOGLE_MAPS_API_KEY = 'AIzaSyD6D4OGAfep-u-N1yz_F--jacBFs1TINR4';
-}
-
 // ======================================================================
 // EXPRESS APP SETUP
 // ======================================================================
@@ -171,6 +165,18 @@ function initializeDatabase() {
         user_data TEXT,
         expires_at DATETIME,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`);
+
+    // Distance Matrix Cache
+    db.run(`CREATE TABLE IF NOT EXISTS distance_cache (
+        origin_lat REAL,
+        origin_lng REAL,
+        dest_lat REAL,
+        dest_lng REAL,
+        distance REAL,
+        duration REAL,
+        cached_at DATETIME,
+        PRIMARY KEY (origin_lat, origin_lng, dest_lat, dest_lng)
     )`);
 
     // Stelle sicher, dass IMMER ein Fahrer existiert


### PR DESCRIPTION
## Summary
- remove hardcoded Google API keys
- require API key at runtime in all services and dockerfile
- create `distance_cache` table
- load and store distance data in cache
- reuse cached distances before calling Google API
- increase batch size for distance calls

## Testing
- `GOOGLE_MAPS_API_KEY=dummykey npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6853d5d3ed388328b22df0ed31397319